### PR TITLE
Remove trailing backtick

### DIFF
--- a/index.md
+++ b/index.md
@@ -142,7 +142,7 @@ is "real"). And `mod_php` is affected due to the nature of PHP. If you are using
 RequestHeader unset Proxy early
 ```
 
-Example for using this in `.htaccess` files:`
+Example for using this in `.htaccess` files:
 
 ```
 <IfModule mod_headers.c>


### PR DESCRIPTION
This was accidentally added by commit https://github.com/httpoxy/httpoxy-org/commit/5d564e870cc35bab8a0f363470841823ecc880c5#diff-d680e8a854a7cbad6d490c445cba2ebaR145.