### PR TITLE
Update CVEs for HTTPoxy

### DIFF
--- a/index.md
+++ b/index.md
@@ -523,10 +523,12 @@ The assigned CVEs so far:
 * CVE-2016-5386: Go
 * CVE-2016-5387: Apache HTTP Server
 * CVE-2016-5388: Apache Tomcat
+* CVE-2016-1000104: mod_fcgi
+* CVE-2016-1000105: Nginx cgi script
 * CVE-2016-1000107: Erlang inets
 * CVE-2016-1000108: YAWS
-* CVE-2016-1000109: HHVM
-* CVE-2016-1000110: Python
+* CVE-2016-1000109: HHVM FastCGI
+* CVE-2016-1000110: Python CGIHandler
 * CVE-2016-1000111: Python Twisted
 * CVE-2016-1000212: lighttpd
 

--- a/index.md
+++ b/index.md
@@ -523,8 +523,12 @@ The assigned CVEs so far:
 * CVE-2016-5386: Go
 * CVE-2016-5387: Apache HTTP Server
 * CVE-2016-5388: Apache Tomcat
+* CVE-2016-1000107: Erlang inets
+* CVE-2016-1000108: YAWS
 * CVE-2016-1000109: HHVM
 * CVE-2016-1000110: Python
+* CVE-2016-1000111: Python Twisted
+
 
 We suspect there may be more CVEs coming for httpoxy, as less common software is checked over. If you
 want to get a CVE assigned for an httpoxy issue, there are a couple of options:

--- a/index.md
+++ b/index.md
@@ -528,7 +528,7 @@ The assigned CVEs so far:
 * CVE-2016-1000109: HHVM
 * CVE-2016-1000110: Python
 * CVE-2016-1000111: Python Twisted
-
+* CVE-2016-1000212: lighttpd
 
 We suspect there may be more CVEs coming for httpoxy, as less common software is checked over. If you
 want to get a CVE assigned for an httpoxy issue, there are a couple of options:


### PR DESCRIPTION
Several more CVEs have been assigned through the DWF. These CVEs have been added to the list on the httpoxy.org page.